### PR TITLE
fix theme detection and mobile toggle overlap

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -9,7 +9,7 @@ export default function LanguageSelector() {
   };
 
   return (
-    <div className="fixed top-4 left-16">
+    <div className="fixed bottom-16 right-4 md:top-4 md:left-16 md:bottom-auto md:right-auto">
       <select
         onChange={changeLanguage}
         value={i18n.language}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -8,7 +8,7 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="fixed top-4 left-4 p-2 rounded-lg bg-primary-100 dark:bg-primary-800 text-primary-800 dark:text-primary-200 hover:bg-primary-200 dark:hover:bg-primary-700 transition-all duration-200"
+      className="fixed bottom-4 right-4 md:top-4 md:left-4 md:bottom-auto md:right-auto p-2 rounded-lg bg-primary-100 dark:bg-primary-800 text-primary-800 dark:text-primary-200 hover:bg-primary-200 dark:hover:bg-primary-700 transition-all duration-200"
       aria-label={t('theme.toggle')}
     >
       {theme === 'light' ? (

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -10,12 +10,12 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const darkThemeMq = window.matchMedia("(prefers-color-scheme: dark)")
-   ? "dark"
-   : "light";
+  const getPreferredTheme = () =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
   const [theme, setTheme] = useState<Theme>(() => {
-    const savedTheme = localStorage.getItem('theme');
-    return (savedTheme as Theme) || darkThemeMq;
+    const savedTheme = localStorage.getItem('theme') as Theme | null;
+    return savedTheme || getPreferredTheme();
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix theme detection to respect OS color scheme
- move theme toggle and language selector on mobile to avoid overlapping with page title

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891e5b44908833298df645e92ab532b